### PR TITLE
Receive config as init args

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Secrets Manager Provider is an Elixir Release provider that loads runtime configurations from [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/).
 
+- [Upgrading to 0.6](docs/upgrading_to_0_6.md)
+
 ## Installation
 
 Add `secrets_manager_provider` to your `deps/0` in your `mix.exs` file. A TOML (`toml`) or JSON (`jason`) library will also need to be included. This can be any library, as long as it implements `decode!/1`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # SecretsManagerProvider
+
 Secrets Manager Provider is an Elixir Release provider that loads runtime configurations from [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/).
 
 ## Installation
-Add `secrets_manager_provider` to your `deps/0` in your `mix.exs` file. A TOML (`toml`) or JSON (`jason`) library will also need to be included. This can be any library, as long as it implements `decode!/1`. 
+
+Add `secrets_manager_provider` to your `deps/0` in your `mix.exs` file. A TOML (`toml`) or JSON (`jason`) library will also need to be included. This can be any library, as long as it implements `decode!/1`.
 
 ```elixir
 defp deps do
@@ -11,38 +13,8 @@ defp deps do
 end
 ```
 
-## Configuration
-### Elixir
-`toml` is the default parser library used by Secrets Manager Provider. Feel free to swap this out with a library of your choice.
-
-```elixir
-config :secrets_manager_provider, :parser, Jason
-```
-
-### AWS
-[ExAws](https://hexdocs.pm/ex_aws/ExAws.html) is the default client used to get secrets from AWS Secrets Manager. Configuration options for `ExAws` can be found [here](https://hexdocs.pm/ex_aws/ExAws.html#module-aws-key-configuration).
-
-The action `secretsmanager:GetSecretValue` must be added to your IAM Role or User. Below is an example of this policy:
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid" : "Stmt2GetSecretValue",  
-            "Effect": "Allow",
-            "Action": [ "secretsmanager:GetSecretValue" ],
-            "Resource": "arn:aws:secretsmanager:<region>:<account_id>:secret:<secret-name>",
-            "Condition" : { 
-                "ForAnyValue:StringLike" : {
-                    "secretsmanager:VersionStage" : "AWSCURRENT" 
-                } 
-            }
-        }
-    ]
-}
-```
-
 ## Usage
+
 Add the following to your `mix.exs` configuration. In this example, the name of the app is `:example`.
 
 ```elixir
@@ -50,21 +22,63 @@ def project do
   [
     app: :example,
     ...
-    releases: [ 
+    releases: [
       example: [
-        config_providers: [{SecretsManagerProvider, {:name, "name"}]
+        config_providers: [{SecretsManagerProvider, [{:name, "secret/name"}]]
       ]
     ]
   ]
 end
 ```
 
-The name of the secret sorted in AWS Secrets Manager can provided in in two ways.
-1. Provide the name directly in the release configurations by using the tuple `{:name, "secret/name"}` for the provider.
-2. Provide the name of a ENV variable where the secret name can be found, `{:env, "secret/name"}`. This option is useful when your release is run in different environments. Make sure the ENV variable is set on the machine or container before starting the release.
+Any configuration can provided in in two ways.
 
-You can store your runtime configurations in AWS Secrets Manager in any format. Below are two examples with TOML and JSON.
-### Toml  (Default)
+1. Provide the configuration value directly in the release configurations by using a tuple `{:name, "secret/name"}`.
+2. Provide the name of a ENV variable where the configuration can be found, `{:name, {:system, "SECRET_NAME"}}`. This option is useful when your release is run in different environments. Make sure the ENV variable is set on the machine or container before starting the release.
+
+## Configuration
+
+### Client
+
+[ExAws](https://hexdocs.pm/ex_aws/ExAws.html) is the default client used to get secrets from AWS Secrets Manager. Configuration options for `ExAws` can be found [here](https://hexdocs.pm/ex_aws/ExAws.html#module-aws-key-configuration).
+
+The action `secretsmanager:GetSecretValue` must be added to your IAM Role or User. Below is an example of this policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Stmt2GetSecretValue",
+      "Effect": "Allow",
+      "Action": ["secretsmanager:GetSecretValue"],
+      "Resource": "arn:aws:secretsmanager:<region>:<account_id>:secret:<secret-name>",
+      "Condition": {
+        "ForAnyValue:StringLike": {
+          "secretsmanager:VersionStage": "AWSCURRENT"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Name
+
+The name or arn of you secret.
+
+### Parser
+
+You can store your runtime configurations in AWS Secrets Manager in any format. `toml` is the default parser library used by Secrets Manager Provider. Feel free to swap this out with a library of your choice.
+
+```elixir
+config_providers: [{SecretsManagerProvider, [{:parser, Jason}]]
+```
+
+Below are two examples with TOML and JSON.
+
+#### Toml (Default)
+
 ```toml
 [example]
 somekey = "key"
@@ -73,11 +87,12 @@ somekey = "key"
 url = "ecto://postgres:postgres@localhost/example_dev"
 ```
 
-### JSON
+#### JSON
+
 ```json
 {
   "example": {
-      "Example.Repo": { "url": "ecto://postgres:postgres@localhost/example_dev"}
+    "Example.Repo": { "url": "ecto://postgres:postgres@localhost/example_dev" }
   }
 }
 ```
@@ -85,10 +100,12 @@ url = "ecto://postgres:postgres@localhost/example_dev"
 The keys are converted to atoms, and the result are merged with existing configs.
 
 ## Code Status
-[![Build Status](#)(https://travis-ci.org/christopherlai/secrets_manager_provider.svg?branch=master)](https://travis-ci.org/christopherlai/secrets_manager_provider)
-[![Hex pm](#)(https://img.shields.io/hexpm/v/secrets_manager_provider.svg?style=flat)](https://hex.pm/packages/secrets_manager_provider)
+
+[![Build Status](https://travis-ci.org/christopherlai/secrets_manager_provider.svg?branch=master)](https://travis-ci.org/christopherlai/secrets_manager_provider)
+[![Hex pm](https://img.shields.io/hexpm/v/secrets_manager_provider.svg?style=flat)](https://hex.pm/packages/secrets_manager_provider)
 
 ## License
+
 The MIT License (MIT)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ def project do
 end
 ```
 
-Any configuration can provided in in two ways.
+The secret name configuration can provided in in two ways.
 
 1. Provide the configuration value directly in the release configurations by using a tuple `{:name, "secret/name"}`.
 2. Provide the name of a ENV variable where the configuration can be found, `{:name, {:system, "SECRET_NAME"}}`. This option is useful when your release is run in different environments. Make sure the ENV variable is set on the machine or container before starting the release.

--- a/docs/upgrading_to_0_6.md
+++ b/docs/upgrading_to_0_6.md
@@ -1,0 +1,42 @@
+# Upgrading From 0.5.x
+
+Following the [Elixir Library Guidelines], since the `0.6.0` release, Secrets Manager Provider
+does not rely anymore on application configuration.
+
+After upgrading the library remove any `:secrets_manager_provider` configuration
+from your config files:
+
+```elixir
+config :secrets_manager_provider, :parser, Jason
+
+```
+
+And add it to the release configuration:
+
+```elixir
+def project do
+  [
+    app: :example,
+    ...
+    releases: [
+      example: [
+        config_providers: [{SecretsManagerProvider, [{:name, Jason}]]
+      ]
+    ]
+  ]
+end
+```
+
+If you were using the ENV variable to set the secret name at runtime, you can replace:
+
+```elixir
+{:env, "SECRET_NAME"}
+```
+
+With the system tuple:
+
+```elixir
+{:name, {:system, "SECRET_NAME"}}
+```
+
+[elixir library guidelines]: https://hexdocs.pm/elixir/master/library-guidelines.html

--- a/lib/secrets_manager_provider.ex
+++ b/lib/secrets_manager_provider.ex
@@ -15,18 +15,15 @@ defmodule SecretsManagerProvider do
   def load(config, args) do
     {:ok, _deps} = Application.ensure_all_started(:hackney)
     {:ok, _deps} = Application.ensure_all_started(:ex_aws)
-    configuration = Configuration.new()
+    configuration = Configuration.new(args)
 
-    args
-    |> get_path()
+    configuration
+    |> Map.get(:name)
     |> configuration.client.get_secrets()
     |> configuration.parser.decode!()
     |> to_keyword()
     |> merge_configs(config)
   end
-
-  defp get_path({:env, name}), do: System.get_env(name)
-  defp get_path({:name, path}), do: path
 
   defp merge_configs(secrets, config) do
     Config.Reader.merge(config, secrets)

--- a/lib/secrets_manager_provider/configuration.ex
+++ b/lib/secrets_manager_provider/configuration.ex
@@ -24,6 +24,6 @@ defmodule SecretsManagerProvider.Configuration do
   end
 
   @spec maybe_get_env(args()) :: args()
-  def maybe_get_env({name, {:system, env}}), do: {name, System.get_env(env)}
+  def maybe_get_env({:name, {:system, env}}), do: {:name, System.get_env(env)}
   def maybe_get_env(field), do: field
 end

--- a/lib/secrets_manager_provider/configuration.ex
+++ b/lib/secrets_manager_provider/configuration.ex
@@ -3,21 +3,27 @@ defmodule SecretsManagerProvider.Configuration do
   Struct for managing configurations like :client and :parser.
   """
 
+  @type args :: [{atom(), any()}]
   @type t :: %__MODULE__{
           client: module(),
+          name: String.t(),
           parser: module()
         }
 
   defstruct client: SecretsManagerProvider.ExAwsClient,
+            name: nil,
             parser: Toml
 
   @doc """
   Returns a new `Configuration` struct with defaults.
   """
-  @spec new :: t()
-  def new do
-    fields = Application.get_all_env(:secrets_manager_provider)
-
-    struct(__MODULE__, fields)
+  @spec new(args()) :: t()
+  def new(args) do
+    fields = Enum.into(args, %{}, &maybe_get_env/1)
+    struct!(__MODULE__, fields)
   end
+
+  @spec maybe_get_env(args()) :: args()
+  def maybe_get_env({name, {:system, env}}), do: {name, System.get_env(env)}
+  def maybe_get_env(field), do: field
 end

--- a/test/secrets_manager_provider/configuration_test.exs
+++ b/test/secrets_manager_provider/configuration_test.exs
@@ -1,13 +1,28 @@
 defmodule SecretsManagerProvider.ConfigurationTest do
   use ExUnit.Case, async: true
+
   alias SecretsManagerProvider.Configuration
 
-  describe "new/0" do
-    test "returns Configuration struct with default" do
-      config = Configuration.new()
+  describe "new/1" do
+    test "returns Configuration struct with default values" do
+      config = Configuration.new([{:name, "secret/name"}])
 
-      assert config.client == SecretsManagerProvider.ExAwsClient
-      assert config.parser == Toml
+      assert config == %Configuration{
+               client: SecretsManagerProvider.ExAwsClient,
+               name: "secret/name",
+               parser: Toml
+             }
+    end
+
+    test ~s("when config field is given in the `{:system, "ENV_NAME"}` format, get environment value) do
+      System.put_env("SECRET_NAME", "secret/name")
+      config = Configuration.new([{:name, {:system, "SECRET_NAME"}}])
+
+      assert config == %Configuration{
+               client: SecretsManagerProvider.ExAwsClient,
+               name: "secret/name",
+               parser: Toml
+             }
     end
   end
 end

--- a/test/secrets_manager_provider/configuration_test.exs
+++ b/test/secrets_manager_provider/configuration_test.exs
@@ -14,7 +14,8 @@ defmodule SecretsManagerProvider.ConfigurationTest do
              }
     end
 
-    test ~s("when config field is given in the `{:system, "ENV_NAME"}` format, get environment value) do
+    test ~s(when config field is given in the `{:system, "ENV_NAME"}` format, ) <>
+           "get environment value" do
       System.put_env("SECRET_NAME", "secret/name")
       config = Configuration.new([{:name, {:system, "SECRET_NAME"}}])
 

--- a/test/secrets_manager_provider_test.exs
+++ b/test/secrets_manager_provider_test.exs
@@ -5,19 +5,26 @@ defmodule SecretsManagerProviderTest do
 
   setup :verify_on_exit!
 
+  setup do
+    {:ok, %{name: "/path/to"}}
+  end
+
   describe "init/1" do
-    test "returns the given path" do
-      assert SecretsManagerProvider.init({:name, "/path/to"}) == {:name, "/path/to"}
+    test "returns the given path", %{name: name} do
+      assert SecretsManagerProvider.init([{:name, name}]) == [{:name, name}]
     end
   end
 
   describe "load/2 with TOML" do
-    setup do
-      Application.put_env(:secrets_manager_provider, :client, SecretsManagerProvider.MockClient)
-      Application.put_env(:secrets_manager_provider, :parser, Toml)
+    setup %{name: name} do
+      args = [
+        {:client, SecretsManagerProvider.MockClient},
+        {:name, name},
+        {:parser, Toml}
+      ]
 
       SecretsManagerProvider.MockClient
-      |> expect(:get_secrets, fn _path ->
+      |> expect(:get_secrets, fn ^name ->
         """
         [toplevel]
         sublevel = "config"
@@ -26,25 +33,28 @@ defmodule SecretsManagerProviderTest do
 
       expected = [toplevel: [sublevel: "config"]]
 
-      {:ok, %{expected: expected}}
+      {:ok, %{args: args, expected: expected}}
     end
 
-    test "returns keyword configurations", %{expected: expected} do
-      assert SecretsManagerProvider.load([], {:name, ""}) == expected
+    test "returns keyword configurations", %{args: args, expected: expected} do
+      assert SecretsManagerProvider.load([], args) == expected
     end
 
-    test "returns merged keyword configurations", %{expected: expected} do
-      assert SecretsManagerProvider.load([toplevel: [sublevel: false]], {:name, ""}) == expected
+    test "returns merged keyword configurations", %{args: args, expected: expected} do
+      assert SecretsManagerProvider.load([toplevel: [sublevel: false]], args) == expected
     end
   end
 
   describe "load/2 with JSON" do
-    setup do
-      Application.put_env(:secrets_manager_provider, :client, SecretsManagerProvider.MockClient)
-      Application.put_env(:secrets_manager_provider, :parser, Jason)
+    setup %{name: name} do
+      args = [
+        {:client, SecretsManagerProvider.MockClient},
+        {:name, name},
+        {:parser, Jason}
+      ]
 
       SecretsManagerProvider.MockClient
-      |> expect(:get_secrets, fn _path ->
+      |> expect(:get_secrets, fn ^name ->
         """
         {"toplevel": {
           "sublevel": "config"
@@ -55,15 +65,15 @@ defmodule SecretsManagerProviderTest do
 
       expected = [toplevel: [sublevel: "config"]]
 
-      {:ok, %{expected: expected}}
+      {:ok, %{args: args, expected: expected}}
     end
 
-    test "returns keyword configurations", %{expected: expected} do
-      assert SecretsManagerProvider.load([], {:env, ""}) == expected
+    test "returns keyword configurations", %{args: args, expected: expected} do
+      assert SecretsManagerProvider.load([], args) == expected
     end
 
-    test "returns merged keyword configurations", %{expected: expected} do
-      assert SecretsManagerProvider.load([toplevel: [sublevel: false]], {:env, ""}) == expected
+    test "returns merged keyword configurations", %{args: args, expected: expected} do
+      assert SecretsManagerProvider.load([toplevel: [sublevel: false]], args) == expected
     end
   end
 end

--- a/test/secrets_manager_provider_test.exs
+++ b/test/secrets_manager_provider_test.exs
@@ -6,7 +6,7 @@ defmodule SecretsManagerProviderTest do
   setup :verify_on_exit!
 
   setup do
-    {:ok, %{name: "/path/to"}}
+    {:ok, name: "/path/to"}
   end
 
   describe "init/1" do
@@ -33,7 +33,7 @@ defmodule SecretsManagerProviderTest do
 
       expected = [toplevel: [sublevel: "config"]]
 
-      {:ok, %{args: args, expected: expected}}
+      {:ok, args: args, expected: expected}
     end
 
     test "returns keyword configurations", %{args: args, expected: expected} do
@@ -65,7 +65,7 @@ defmodule SecretsManagerProviderTest do
 
       expected = [toplevel: [sublevel: "config"]]
 
-      {:ok, %{args: args, expected: expected}}
+      {:ok, args: args, expected: expected}
     end
 
     test "returns keyword configurations", %{args: args, expected: expected} do


### PR DESCRIPTION
This PR is a proposal to avoid application config and receive configuration through the init function parameter. 

Besides the fact that this is a recommendation from the [Library Guidelines](https://hexdocs.pm/elixir/master/library-guidelines.html#avoid-application-configuration) we also found a problem in a specific scenario where we were trying to run a database migration with `/path/to/app eval "Release.migrate(Repo)"`. We couldn't override the library default parser because the application config was not loaded (the app is loaded only inside the `migrate` function), the parser raises an exception when it tries to parse a JSON and the `migrate` is never called. 