### PR TITLE
Fix bug with lists inside configs

### DIFF
--- a/lib/secrets_manager_provider/utils.ex
+++ b/lib/secrets_manager_provider/utils.ex
@@ -10,6 +10,12 @@ defmodule SecretsManagerProvider.Utils do
     end
   end
 
+  def to_keyword(config) when is_list(config) do
+    for item <- config do
+      to_keyword(item)
+    end
+  end
+
   def to_keyword(config), do: config
 
   def to_atom(<<k::utf8, _rest::binary>> = key) when k >= ?A and k <= ?Z do

--- a/test/secrets_manager_provider/utils_test.exs
+++ b/test/secrets_manager_provider/utils_test.exs
@@ -16,6 +16,24 @@ defmodule SecretsManagerProvider.UtilsTest do
       assert Utils.to_keyword(%{"database" => %{"url" => "http://url/to"}}) == expected
     end
 
+    test "handles lists" do
+      expected = [
+        databases: [
+          [name: "shard1", url: "http://shard1"],
+          [name: "shard2", url: "http://shard2"]
+        ]
+      ]
+
+      config = %{
+        "databases" => [
+          %{"name" => "shard1", "url" => "http://shard1"},
+          %{"name" => "shard2", "url" => "http://shard2"}
+        ]
+      }
+
+      assert Utils.to_keyword(config) == expected
+    end
+
     test "returns the passed value if it is not a list or map" do
       assert Utils.to_keyword("http://database") == "http://database"
     end


### PR DESCRIPTION
Lists inside configs were not handled properly by `Utils.to_keyword`. They were being ignored, and any keys inside maps inside the lists were not being converted to atoms.